### PR TITLE
use https for link that supports it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 - Write and update tests.
 - Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
-- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Write a [good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
 Work in Progress pull requests are also welcome to get feedback early on, or if there is something blocked you.
 


### PR DESCRIPTION
this domain supports https, so we might as well use that for the link.

-----
[View rendered CONTRIBUTING.md](https://github.com/lpmi-13/learning-lab/blob/use_https_link/CONTRIBUTING.md)